### PR TITLE
Allow user to specify temporary upload directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ const config = "/path/to/filemanager.config.json";	//Change this to the actual l
 var app = express();
 
 //Filemanager route
-app.use( '/filemanager', filemanager( "/path/to/dir", config ) );
+app.use( '/filemanager', filemanager( "/path/to/dir", config, '/temporary/upload/dir' ) );
 // '/filemanager' is the connector url. 
 // Don't forget to set it in the api.connectorUrl of `filemanager.config.json` for the frontend
 

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ const paths = require('path');
 const multer = require('multer');
 paths.posix = require('path-posix');
 
-const router = express.Router(); // eslint-disable-line
-const upload = multer({dest: 'public/'});
+const router = express.Router(); // eslint-disable-lin
 
-module.exports = (__appRoot, configPath) => { // eslint-disable-line max-statements
+module.exports = (__appRoot, configPath, dest='public/') => { // eslint-disable-line max-statements
+	const upload = multer({dest: dest});
 	//Init config
 	if ( typeof( configPath ) == "string" ) {
 		config = require(configPath);


### PR DESCRIPTION
I added a parameter to the initialization of the module to allow a user to specify where to initially save uploaded files (multer `dest` param).

I made this as a solution to the `fs.rename`. If the destination path is mounted in a different device as the multer destination folder, a `EXDEV` is raised.