### PR TITLE
Enable wrapping of the middleware by another (e.g. to provide authN)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ TODO: API functions to integrate
 var config;
 const express = require('express');
 const fs = require('fs-extra');
+const mv = require('mv');
 const paths = require('path');
 const multer = require('multer');
 paths.posix = require('path-posix');
@@ -21,10 +22,10 @@ const upload = multer({dest: 'public/'});
 
 module.exports = (__appRoot, configPath) => { // eslint-disable-line max-statements
 	//Init config
-	if ( typeof( configPath ) == "string" ) {
+	if ( typeof( configPath ) === "string" ) {
 		config = require(configPath);
 	}
-	else if( typeof( configPath ) == "object"  ){
+	else if( typeof( configPath ) === "object"  ){
 		config = configPath;
 	}
 
@@ -399,7 +400,8 @@ module.exports = (__appRoot, configPath) => { // eslint-disable-line max-stateme
 				pp.isDirectory ? files[$index].originalname : pp.filename
 			); // not sure if this is the best way to handle this or not
 
-			fs.rename(oldfilename, newfilename, (err) => {
+			// Use MV since fs.rename won't work across filesystems
+			mv(oldfilename, newfilename, (err) => {
 				if (err) {
 					loopInfo.error = true;
 					console.log('savefiles error -> ', err); // eslint-disable-line no-console

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^4.15.2",
     "fs-extra": "^7.0.1",
     "multer": "^1.3.0",
+    "mv": "^2.1.1",
     "path-posix": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
1. Allow responding with next() (and embedding the object response in the req object)
2. Allow having the POST body already read; if req.body exists, just use it rather than going through multer.  This is because we can’t snoop the request body upstream, and cannot rewind it.
3. Use mv instead of fs.rename so files can be moved across volumes